### PR TITLE
Menampilkan tautan Login secara permanen

### DIFF
--- a/src/app/_layout-components/navbar/components/guest-navbar-items.tsx
+++ b/src/app/_layout-components/navbar/components/guest-navbar-items.tsx
@@ -14,13 +14,11 @@ import ThemeSwitcher from '@/components/theme-switcher'
 export function GuestNavbarItems() {
   return (
     <>
-      {process.env.NODE_ENV !== 'production' && (
-        <NavbarItem>
-          <Link href={PageUrlEnum.LOGIN} as={NextLink}>
-            Login
-          </Link>
-        </NavbarItem>
-      )}
+      <NavbarItem>
+        <Link href={PageUrlEnum.LOGIN} as={NextLink}>
+          Login
+        </Link>
+      </NavbarItem>
 
       <NavbarItem>
         <ThemeSwitcher />


### PR DESCRIPTION
Sebelumnya, tautan Login hanya ditampilkan saat aplikasi tidak berjalan di lingkungan produksi. Perubahan ini memastikan tautan Login selalu terlihat oleh pengguna tamu, menyederhanakan navigasi dan akses.